### PR TITLE
docs: fix patching external client/resource docs

### DIFF
--- a/docs/docs/getting_started.rst
+++ b/docs/docs/getting_started.rst
@@ -288,7 +288,7 @@ If it is not possible to rearrange imports, we can patch the boto3-client or res
 .. sourcecode:: python
 
     # The client can come from an import, an __init__-file, wherever..
-    client = boto3.client("s3")
+    outside_client = boto3.client("s3")
     s3 = boto3.resource("s3")
 
     @mock_s3
@@ -297,7 +297,7 @@ If it is not possible to rearrange imports, we can patch the boto3-client or res
         patch_client(outside_client)
         patch_resource(s3)
 
-        assert client.list_buckets()["Buckets"] == []
+        assert outside_client.list_buckets()["Buckets"] == []
 
         assert list(s3.buckets.all()) == []
 


### PR DESCRIPTION
## What 
The documentation sample code [currently in master](https://docs.getmoto.org/en/latest/docs/getting_started.html?highlight=caveats#patching-the-client-or-resource) runs into a "NameError: name `client` is not defined" exception if executed. 

This change updates the documentation to refer to the externally provided `client` as `outside_client` for example clarity + functional accuracy.
